### PR TITLE
Three point seven

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Check documentation (mdoc)
         # Verifies that code snippets in docs compile
         # Pass arguments to the mdoc task within quotes for sbt
-        run: sbt "mdoc --check" # <-- MODIFIED THIS LINE
+        run: sbt "mdoc --check" #
 
       - name: Package artifact and generate POM
         # Creates the JAR and POM files needed for publishing

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -9,6 +9,10 @@ rules = [
   RedundantSyntax,
 ]
 
+ExplicitResultTypes {
+  fetchScala3CompilerArtifactsOnVersionMismatch = true
+}
+
 DisableSyntax {
   noVars = true
   noThrows = true
@@ -21,9 +25,10 @@ DisableSyntax {
   noContravariant = true
   noAsInstanceOf = true
 }
+
 OrganizeImports {
   groupedImports = Keep
-;   groups = ["*", "re:(javax?|scala)\\.", "net.ghoula"]
+  groups = ["*", "re:(javax?|scala)\\.", "net.ghoula"]
   removeUnused = true
   targetDialect = Scala3
 }

--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@ detailed error messages useful for debugging or user feedback.
 
 * **Type Safety:** Clearly distinguish between valid results and accumulated errors at compile time using
   `ValidationResult[A]`. Eliminate runtime errors caused by unexpected validation states.
-* **Named Tuple Support:** 🆕 Field-aware error messages for Scala 3.7's named tuples, with preserved backward
-  compatibility.
+* **Named Tuple Support:** 🆕 Field-aware error messages for Scala 3.7's named tuples, with preserved backward compatibility.
 * **Minimal Boilerplate:** Derive `Validator` instances automatically for case classes using compile-time macros,
   significantly reducing repetitive validation logic. Focus on your rules, not the wiring.
 * **Flexible Error Handling:** Choose the strategy that fits your use case:
-    * **Error Accumulation** (default): Collect all validation failures, ideal for reporting multiple issues (e.g., in
-      UIs or API responses).
-    * **Fail-Fast**: Stop validation immediately on the first failure, suitable for performance-sensitive pipelines.
+  * **Error Accumulation** (default): Collect all validation failures, ideal for reporting multiple issues (e.g., in
+    UIs or API responses).
+  * **Fail-Fast**: Stop validation immediately on the first failure, suitable for performance-sensitive pipelines.
 * **Actionable Error Reports:** Generate detailed `ValidationError` objects containing precise field paths, validation
   rule specifics (like expected vs. actual values), and optional codes/severity, making debugging and error reporting
   straightforward.
@@ -38,8 +37,7 @@ libraryDependencies += "net.ghoula" %% "valar" % "0.3.0"
 
 Here's a basic example illustrating how to use Valar for validating a simple case class:
 
-*Note: Valar provides default validators for `String` (non-empty) and `Int` (non-negative). This example explicitly
-defines `given` instances to demonstrate how you can define custom logic or override the defaults.*
+*Note: Valar provides default validators for `String` (non-empty) and `Int` (non-negative). This example explicitly defines `given` instances to demonstrate how you can define custom logic or override the defaults.*
 
 ```scala
 import net.ghoula.valar.{ValidationResult, Validator}
@@ -120,8 +118,7 @@ result match {
 
 ## Named Tuples Support 🆕
 
-Valar 0.3.0 adds support for Scala 3.7's named tuples, providing improved error messages that include actual field
-names:
+Valar 0.3.0 adds support for Scala 3.7's named tuples, providing improved error messages that include actual field names:
 
 ```scala
 import net.ghoula.valar.*
@@ -171,13 +168,13 @@ tupleResult match {
       println(s"Field: ${error.fieldPath.mkString(".")}")
       println(s"Error: ${error.message}")
     }
-  // Output includes meaningful field names:
-  // Field: name
-  // Error: String must not be empty
-  // Field: age  
-  // Error: Int must be non-negative
-  // Field: email
-  // Error: String must not be empty
+    // Output includes meaningful field names:
+    // Field: name
+    // Error: String must not be empty
+    // Field: age  
+    // Error: Int must be non-negative
+    // Field: email
+    // Error: String must not be empty
 }
 // Field: name
 // Error: Invalid field: name, field type: String: Name must not be empty
@@ -186,7 +183,6 @@ tupleResult match {
 ```
 
 **Key Benefits:**
-
 - **Enhanced debugging** - Error messages include meaningful field names
 - **Zero runtime overhead** - Field names are extracted at compile time
 - **Future-proof** - Compatible with the upcoming Scala 3 LTS version
@@ -200,8 +196,7 @@ validator.validate(regularTuple) // Works but shows generic positions in errors
 
 ## Defining Custom Validators
 
-Valar allows you to define custom validators easily by implementing the `Validator` typeclass. Here's an example
-demonstrating how you might define a validator for an `Age` type:
+Valar allows you to define custom validators easily by implementing the `Validator` typeclass. Here's an example demonstrating how you might define a validator for an `Age` type:
 
 ```scala
 import net.ghoula.valar.*
@@ -265,7 +260,7 @@ object MyAgeModule {
 
     // Define a Validator instance for Age to integrate with Valar's validation system
     given ageValidator: Validator[Age] with {
-      def validate(value: Age): ValidationResult[Age] = Age.apply(value)
+      def validate(value: Age): ValidationResult[Age] = Age.apply (value)
     }
   }
 }
@@ -358,15 +353,11 @@ case class Config(host: String, port: Int)
 given configValidator: Validator[Config] = deriveValidatorMacro
 ```
 
-**Important Note on Derivation:** Automatic derivation with `deriveValidatorMacro` requires implicit `Validator`
-instances to be available in scope for **all** field types within the case class. If a validator for any field type is
-missing, **compilation will fail**. This strictness ensures that all fields are explicitly considered during validation,
-preventing silent omissions. See the "Built-in Validators" section below for types supported out-of-the-box.
+**Important Note on Derivation:** Automatic derivation with `deriveValidatorMacro` requires implicit `Validator` instances to be available in scope for **all** field types within the case class. If a validator for any field type is missing, **compilation will fail**. This strictness ensures that all fields are explicitly considered during validation, preventing silent omissions. See the "Built-in Validators" section below for types supported out-of-the-box.
 
 ### Helper Methods
 
-Common validations like non-empty strings, numeric ranges, regex patterns, and more are available in
-`net.ghoula.valar.ValidationHelpers`:
+Common validations like non-empty strings, numeric ranges, regex patterns, and more are available in `net.ghoula.valar.ValidationHelpers`:
 
 ```scala
 import net.ghoula.valar.ValidationHelpers.*
@@ -392,25 +383,18 @@ optional(Option.empty[String]) // Validates inner value if Some, passes if None
 
 ## Built-in Validators
 
-Valar provides `given Validator` instances out-of-the-box for many common types to ease setup and support derivation.
-This includes:
+Valar provides `given Validator` instances out-of-the-box for many common types to ease setup and support derivation. This includes:
 
-* **Scala Primitives:** `Int` (non-negative), `String` (non-empty), `Boolean`, `Long`, `Double` (finite), `Float` (
-  finite), `Byte`, `Short`, `Char`, `Unit`.
+* **Scala Primitives:** `Int` (non-negative), `String` (non-empty), `Boolean`, `Long`, `Double` (finite), `Float` (finite), `Byte`, `Short`, `Char`, `Unit`.
 * **Other Scala Types:** `BigInt`, `BigDecimal`, `Symbol`.
-* **Common Java Types:** `java.util.UUID`, `java.time.Instant`, `java.time.LocalDate`, `java.time.LocalDateTime`,
-  `java.time.ZonedDateTime`, `java.time.LocalTime`, `java.time.Duration`.
-* **Standard Collections:** `Option`, `List`, `Vector`, `Seq`, `Set`, `Array`, `ArraySeq`, `Map` (provided validators
-  exist for their element/key/value types).
-* **Tuple Types:**
-    * **Named tuples** 🆕 - Enhanced error messages with actual field names
-    * **Regular tuples** - Backward compatible validation (field names not available in errors)
+* **Common Java Types:** `java.util.UUID`, `java.time.Instant`, `java.time.LocalDate`, `java.time.LocalDateTime`, `java.time.ZonedDateTime`, `java.time.LocalTime`, `java.time.Duration`.
+* **Standard Collections:** `Option`, `List`, `Vector`, `Seq`, `Set`, `Array`, `ArraySeq`, `Map` (provided validators exist for their element/key/value types).
+* **Tuple Types:** 
+  * **Named tuples** 🆕 - Enhanced error messages with actual field names
+  * **Regular tuples** - Backward compatible validation (field names not available in errors)
 * **Intersection (`&`) and Union (`|`) Types:** Provided corresponding validators for the constituent types exist.
 
-Most built-in validators for scalar types (excluding those with obvious constraints like `Int`, `String`, `Float`,
-`Double`) are **pass-through** validators, meaning they always return `Valid` by default. This ensures derivation
-compiles without imposing arbitrary rules. You should define custom validators if you need specific constraints for
-these types (e.g., range checks for `Long`, specific formats for `UUID`).
+Most built-in validators for scalar types (excluding those with obvious constraints like `Int`, `String`, `Float`, `Double`) are **pass-through** validators, meaning they always return `Valid` by default. This ensures derivation compiles without imposing arbitrary rules. You should define custom validators if you need specific constraints for these types (e.g., range checks for `Long`, specific formats for `UUID`).
 
 ## Migration Guide
 
@@ -434,7 +418,6 @@ namedValidator.validate(namedTuple) // Errors include field names!
 **Breaking Changes:** None! This is a backward-compatible release.
 
 **To adopt named tuples:**
-
 1. Define your tuple types with field names: `type Person = (name: String, age: Int)`
 2. Use automatic derivation: `given Validator[Person] = Validator.deriveValidatorMacro`
 3. Enjoy enhanced error messages with actual field names
@@ -444,13 +427,8 @@ namedValidator.validate(namedTuple) // Errors include field names!
 - **Scala:** 3.4+ (recommended: 3.7+)
 - **Dependencies:** None (zero external dependencies)
 
-> **Note on Scala 3.7**: Scala 3.7 introduces changes to Givens prioritization which may affect how validators are
-> resolved when multiple instances are available. If you define custom validators that could potentially conflict (like
-> for type aliases or inheritance hierarchies), you may need to be more explicit about which validator to use or test
-> thoroughly with your specific Scala version. See
-> the [Scala documentation](https://scala-lang.org/2024/08/19/given-priority-change-3.7.html) for details.
+> **Note on Scala 3.7**: Scala 3.7 introduces changes to Givens prioritization which may affect how validators are resolved when multiple instances are available. If you define custom validators that could potentially conflict (like for type aliases or inheritance hierarchies), you may need to be more explicit about which validator to use or test thoroughly with your specific Scala version. See the [Scala documentation](https://scala-lang.org/2024/08/19/given-priority-change-3.7.html) for details.
 
 ## License
 
-Valar is licensed under the **MIT License**. See the [LICENSE](https://github.com/hakimjonas/valar/blob/main/LICENSE)
-file for details.
+Valar is licensed under the **MIT License**. See the [LICENSE](https://github.com/hakimjonas/valar/blob/main/LICENSE) file for details.

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ import _root_.mdoc.MdocPlugin
 // ===== Build‑wide Settings =====
 ThisBuild / organization := "net.ghoula"
 ThisBuild / versionScheme := Some("early-semver")
-ThisBuild / scalaVersion := "3.6.4"
+ThisBuild / scalaVersion := "3.7.1"
 ThisBuild / homepage := Some(url("https://github.com/hakimjonas/valar"))
 ThisBuild / licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
 ThisBuild / developers := List(
@@ -44,8 +44,8 @@ lazy val valar = (project in file("."))
   .settings(
     name := "valar",
     libraryDependencies ++= Seq(
-      "org.specs2" %% "specs2-core" % "5.6.2" % Test,
-      "org.specs2" %% "specs2-matcher-extra" % "5.6.2" % Test
+      "org.specs2" %% "specs2-core" % "5.6.3" % Test,
+      "org.specs2" %% "specs2-matcher-extra" % "5.6.3" % Test
     ),
     // sbt-pgp signing configuration
     usePgpKeyHex("9614A0CE1CE76975"),

--- a/docs-src/README.md
+++ b/docs-src/README.md
@@ -4,7 +4,6 @@
 [![Scala CI and GitHub Release](https://github.com/hakimjonas/valar/actions/workflows/scala.yml/badge.svg)](https://github.com/hakimjonas/valar/actions/workflows/scala.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 
-
 Valar is a validation library for Scala 3 designed for clarity and ease of use. It leverages Scala 3's type system and
 metaprogramming (macros) to help you define complex validation rules with less boilerplate, while providing structured,
 detailed error messages useful for debugging or user feedback.
@@ -13,6 +12,7 @@ detailed error messages useful for debugging or user feedback.
 
 * **Type Safety:** Clearly distinguish between valid results and accumulated errors at compile time using
   `ValidationResult[A]`. Eliminate runtime errors caused by unexpected validation states.
+* **Named Tuple Support:** 🆕 Field-aware error messages for Scala 3.7's named tuples, with preserved backward compatibility.
 * **Minimal Boilerplate:** Derive `Validator` instances automatically for case classes using compile-time macros,
   significantly reducing repetitive validation logic. Focus on your rules, not the wiring.
 * **Flexible Error Handling:** Choose the strategy that fits your use case:
@@ -30,7 +30,7 @@ detailed error messages useful for debugging or user feedback.
 Add to your `build.sbt`:
 
 ```scala
-libraryDependencies += "net.ghoula" %% "valar" % "0.2.6"
+libraryDependencies += "net.ghoula" %% "valar" % "0.3.0"
 ````
 
 ## Basic Usage Example
@@ -88,7 +88,53 @@ result match {
     println("Validation Failed:")
     println(errors.map(_.prettyPrint(indent = 2)).mkString("\n"))
 }
+```
 
+## Named Tuples Support 🆕
+
+Valar 0.3.0 adds support for Scala 3.7's named tuples, providing improved error messages that include actual field names:
+
+```scala mdoc
+import net.ghoula.valar.*
+
+// Define a named tuple type with meaningful field names
+type PersonTuple = (name: String, age: Int, email: String)
+
+// Automatic derivation works seamlessly with named tuples
+given Validator[PersonTuple] = Validator.deriveValidatorMacro
+
+val invalidPerson: PersonTuple = (name = "", age = -10, email = "bad-email")
+val tupleResult = summon[Validator[PersonTuple]].validate(invalidPerson)
+
+// Error messages now include actual field names for enhanced debugging!
+tupleResult match {
+  case ValidationResult.Valid(validPerson) =>
+    println(s"Valid person: $validPerson")
+  case ValidationResult.Invalid(errors) =>
+    errors.foreach { error =>
+      println(s"Field: ${error.fieldPath.mkString(".")}")
+      println(s"Error: ${error.message}")
+    }
+    // Output includes meaningful field names:
+    // Field: name
+    // Error: String must not be empty
+    // Field: age  
+    // Error: Int must be non-negative
+    // Field: email
+    // Error: String must not be empty
+}
+```
+
+**Key Benefits:**
+- **Enhanced debugging** - Error messages include meaningful field names
+- **Zero runtime overhead** - Field names are extracted at compile time
+- **Future-proof** - Compatible with the upcoming Scala 3 LTS version
+
+```scala
+// Regular tuples continue to work as before
+val regularTuple: (String, Int) = ("", -5)
+val validator = summon[Validator[(String, Int)]]
+validator.validate(regularTuple) // Works but shows generic positions in errors
 ```
 
 ## Defining Custom Validators
@@ -97,16 +143,22 @@ Valar allows you to define custom validators easily by implementing the `Validat
 
 ```scala mdoc
 import net.ghoula.valar.*
-import net.ghoula.valar.ValidationErrors.{ValidationError, ValidationException}
+import net.ghoula.valar.ValidationErrors.ValidationError
 import net.ghoula.valar.ValidationHelpers.*
 import net.ghoula.valar.ValidationResult.{Invalid, Valid}
 import scala.util.Either
+
+// Example using ValidationHelpers directly
+val emailRegex = "[^@]+@[^@]+\\.[^@]+".r
+val emailValidationResult = regexMatch("user@example.com", emailRegex)(email => s"Invalid email format: $email")
+println(s"Email validation result: $emailValidationResult")
 
 // Create a module to encapsulate an opaque type with validation
 object MyAgeModule {
 
   // Define an opaque type to enforce validation at compile time
-  opaque type Age = Int
+  opaque
+  type Age = Int
 
   object Age {
     /**
@@ -132,7 +184,7 @@ object MyAgeModule {
     def apply(value: Int): ValidationResult[Age] = {
       validateEither(value) match {
         case Right(age) => Valid(age)
-        case Left(err)  => Invalid(Vector(err))
+        case Left(err) => Invalid(Vector(err))
       }
     }
 
@@ -146,12 +198,13 @@ object MyAgeModule {
 
     // Define a Validator instance for Age to integrate with Valar's validation system
     given ageValidator: Validator[Age] with {
-      def validate(value: Age): ValidationResult[Age] = Age.apply(value)
+      def validate(value: Age): ValidationResult[Age] = Age.apply (value)
     }
   }
 }
 
 // Usage example showing how to work with the validated type
+
 import MyAgeModule.Age
 
 println("--- Testing Validated Age Type ---")
@@ -163,12 +216,12 @@ val invalidAgeResult = Age.validateEither(-3)
 // Handle validation results
 validAgeResult match {
   case Right(age) => println(s"Valid age: $age")
-  case Left(e)    => println(s"Invalid creation: ${e.prettyPrint()}")
+  case Left(e) => println(s"Invalid creation: ${e.prettyPrint()}")
 }
 
 invalidAgeResult match {
   case Right(age) => println(s"Valid age: $age")
-  case Left(e)    => println(s"Invalid creation: ${e.prettyPrint()}")
+  case Left(e) => println(s"Invalid creation: ${e.prettyPrint()}")
 }
 
 ```
@@ -242,7 +295,7 @@ nonEmpty("value") // Returns Valid("value")
 
 // Numeric validations
 positiveInt(5) // Validates integer is positive
-inRange(3, 1, 10)() // Validates value is within inclusive range [1, 10]
+inRange(3, 1, 10)() // Validates value is within the inclusive range [1, 10]
 
 // Pattern matching validation
 regexMatch("abc123", "[a-z]+[0-9]+")() // Validates string matches the pattern
@@ -260,10 +313,45 @@ Valar provides `given Validator` instances out-of-the-box for many common types 
 * **Other Scala Types:** `BigInt`, `BigDecimal`, `Symbol`.
 * **Common Java Types:** `java.util.UUID`, `java.time.Instant`, `java.time.LocalDate`, `java.time.LocalDateTime`, `java.time.ZonedDateTime`, `java.time.LocalTime`, `java.time.Duration`.
 * **Standard Collections:** `Option`, `List`, `Vector`, `Seq`, `Set`, `Array`, `ArraySeq`, `Map` (provided validators exist for their element/key/value types).
-* **Tuple Types:** Validators for tuples are derived implicitly when deriving for case classes.
+* **Tuple Types:** 
+  * **Named tuples** 🆕 - Enhanced error messages with actual field names
+  * **Regular tuples** - Backward compatible validation (field names not available in errors)
 * **Intersection (`&`) and Union (`|`) Types:** Provided corresponding validators for the constituent types exist.
 
 Most built-in validators for scalar types (excluding those with obvious constraints like `Int`, `String`, `Float`, `Double`) are **pass-through** validators, meaning they always return `Valid` by default. This ensures derivation compiles without imposing arbitrary rules. You should define custom validators if you need specific constraints for these types (e.g., range checks for `Long`, specific formats for `UUID`).
+
+## Migration Guide
+
+### From 0.2.x to 0.3.0
+
+**Named Tuples** are a **completely optional** enhancement. Your existing code continues to work unchanged:
+
+```scala
+// ✅ This still works exactly as before
+val regularTuple: (String, Int) = ("test", 42)
+val validator = summon[Validator[(String, Int)]]
+validator.validate(regularTuple)
+
+// ✅ New: Enhanced error messages with named tuples
+type NamedTuple = (name: String, age: Int)
+val namedTuple: NamedTuple = (name = "test", age = 42)
+val namedValidator = summon[Validator[NamedTuple]]
+namedValidator.validate(namedTuple) // Errors include field names!
+```
+
+**Breaking Changes:** None! This is a backward-compatible release.
+
+**To adopt named tuples:**
+1. Define your tuple types with field names: `type Person = (name: String, age: Int)`
+2. Use automatic derivation: `given Validator[Person] = Validator.deriveValidatorMacro`
+3. Enjoy enhanced error messages with actual field names
+
+## Compatibility
+
+- **Scala:** 3.4+ (recommended: 3.7+)
+- **Dependencies:** None (zero external dependencies)
+
+> **Note on Scala 3.7**: Scala 3.7 introduces changes to Givens prioritization which may affect how validators are resolved when multiple instances are available. If you define custom validators that could potentially conflict (like for type aliases or inheritance hierarchies), you may need to be more explicit about which validator to use or test thoroughly with your specific Scala version. See the [Scala documentation](https://scala-lang.org/2024/08/19/given-priority-change-3.7.html) for details.
 
 ## License
 

--- a/docs-src/usage/migration.md
+++ b/docs-src/usage/migration.md
@@ -1,0 +1,59 @@
+## Migration Guide
+
+### Scala 3.7 Givens Prioritization Changes
+
+Scala 3.7 changes how the compiler resolves given instances when multiple candidates are available. Previously, the compiler would select the most specific subtype, but now it chooses based on different prioritization rules.
+
+This may affect your code if:
+
+1. You have multiple validator instances for the same type or related types (e.g., through type aliases or inheritance)
+2. You rely on implicit resolution to select the correct validator
+
+#### Potential Issues
+
+The most common issue is with type aliases, where you might have defined:
+
+```scala
+type Email = String
+
+// General validator
+given Validator[String] with { ... }
+
+// More specific validator
+given Validator[Email] with { ... }
+
+// Which one gets used? In 3.6 vs 3.7 it might be different!
+val result = summon[Validator[Email]].validate(email)
+```
+
+#### Solutions
+
+1. **Explicit imports**: Place validators in objects and import only the ones you need
+
+```scala
+object validators {
+  given stringValidator: Validator[String] with { ... }
+  given emailValidator: Validator[Email] with { ... }
+}
+
+// Be explicit about which one to use
+import validators.emailValidator
+```
+
+2. **Named instances**: Give your validators explicit names and summon them by name
+
+```scala
+given generalStringValidator: Validator[String] with { ... }
+given specificEmailValidator: Validator[Email] with { ... }
+
+// Use the specific one explicitly
+val result = specificEmailValidator.validate(email)
+```
+
+3. **Extension methods**: Define your validation logic as extension methods to avoid ambiguity
+
+```scala
+extension (email: Email) {
+  def validate: ValidationResult[Email] = { ... }
+}
+```

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // Formatting & linting
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 
 // Documentation
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.7.1")

--- a/src/main/scala/net/ghoula/valar/ValidationResult.scala
+++ b/src/main/scala/net/ghoula/valar/ValidationResult.scala
@@ -1,10 +1,10 @@
 package net.ghoula.valar
 
-import net.ghoula.valar.ValidationErrors.{ValidationError, ValidationException}
-import net.ghoula.valar.internal.{ErrorAccumulator, MacroHelpers}
-
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
+
+import net.ghoula.valar.ValidationErrors.{ValidationError, ValidationException}
+import net.ghoula.valar.internal.{ErrorAccumulator, MacroHelpers}
 
 /** Represents the result of a validation process, either a valid value or validation errors.
   *

--- a/src/main/scala/net/ghoula/valar/Validator.scala
+++ b/src/main/scala/net/ghoula/valar/Validator.scala
@@ -1,10 +1,5 @@
 package net.ghoula.valar
 
-import net.ghoula.valar.ValidationErrors.ValidationError
-import net.ghoula.valar.ValidationHelpers.*
-import net.ghoula.valar.ValidationResult.{validateUnion, given}
-import net.ghoula.valar.internal.MacroHelpers
-
 import java.time.{Duration, Instant, LocalDate, LocalDateTime, LocalTime, ZonedDateTime}
 import java.util.UUID
 import scala.collection.immutable.ArraySeq
@@ -12,6 +7,11 @@ import scala.compiletime.{constValueTuple, summonInline}
 import scala.deriving.Mirror
 import scala.quoted.{Expr, Quotes, Type}
 import scala.reflect.ClassTag
+
+import net.ghoula.valar.ValidationErrors.ValidationError
+import net.ghoula.valar.ValidationHelpers.*
+import net.ghoula.valar.ValidationResult.{validateUnion, given}
+import net.ghoula.valar.internal.MacroHelpers
 
 /** A typeclass for defining custom validation logic for type `A`.
   *

--- a/src/main/scala/net/ghoula/valar/internal/MacroHelpers.scala
+++ b/src/main/scala/net/ghoula/valar/internal/MacroHelpers.scala
@@ -5,7 +5,7 @@ import scala.quoted.{Expr, Quotes, Type}
 
 import net.ghoula.valar.Validator
 
-/** Internal helper methods for macros, primarily for type casting which is inherently unsafe but
+/** Internal helper methods for macros, primarily for type casting - which is inherently unsafe but
   * necessary when bridging compile-time types and runtime values in macros or dealing with
   * unavoidable type erasure limitations (like in `validateUnion`). Use with extreme caution, only
   * when macro logic guarantees type compatibility.

--- a/src/main/scala/net/ghoula/valar/internal/MacroHelpers.scala
+++ b/src/main/scala/net/ghoula/valar/internal/MacroHelpers.scala
@@ -1,8 +1,9 @@
 package net.ghoula.valar.internal
 
-import net.ghoula.valar.Validator
-
+import scala.annotation.unused
 import scala.quoted.{Expr, Quotes, Type}
+
+import net.ghoula.valar.Validator
 
 /** Internal helper methods for macros, primarily for type casting which is inherently unsafe but
   * necessary when bridging compile-time types and runtime values in macros or dealing with
@@ -39,7 +40,7 @@ object MacroHelpers {
   import Upcast.{apply as upcastApply, validator as upcastValidatorHelper}
 
   /** Casts a `quoted.Expr[Any]` to a `quoted.Expr[T]` within a macro context. */
-  def castExpr[T: Type](expr: Expr[Any])(using Quotes): Expr[T] =
+  def castExpr[T: Type](expr: Expr[Any])(using @unused quotes: Quotes): Expr[T] =
     upcastApply[Expr[Any], Expr[T]](expr)
 
   /** Casts a runtime value `value` to type `T`. Equivalent to `upcastTo`. */

--- a/src/test/scala/net/ghoula/valar/GivensPrioritizationSpec.scala
+++ b/src/test/scala/net/ghoula/valar/GivensPrioritizationSpec.scala
@@ -1,0 +1,148 @@
+package net.ghoula.valar
+
+import org.specs2.matcher.{Matchers, ResultMatchers, TraversableMatchers}
+import org.specs2.mutable.Specification
+
+import scala.language.implicitConversions
+
+/** Test to verify compatibility with Scala 3.7's new givens prioritization rules. */
+object GivensPrioritizationSpec extends Specification with Matchers with TraversableMatchers with ResultMatchers {
+
+  "Given prioritization in validators" should {
+
+    "demonstrate advanced prioritization with using clauses" in {
+      type Email = String
+
+      given stringValidator: Validator[String] with {
+        def validate(s: String): ValidationResult[String] =
+          ValidationResult.Valid("string: " + s)
+      }
+
+      given emailValidator: Validator[Email] with {
+        def validate(e: Email): ValidationResult[Email] =
+          ValidationResult.Valid("email: " + e)
+      }
+
+      /** Helper functions that use explicit using clauses to control validator selection. */
+      def validateWithStringValidator(s: String)(using v: Validator[String]): ValidationResult[String] =
+        v.validate(s)
+
+      def validateWithEmailValidator(e: Email)(using v: Validator[Email]): ValidationResult[Email] =
+        v.validate(e)
+
+      val email: Email = "user@example.com"
+
+      val stringResult = validateWithStringValidator(email)(using stringValidator)
+      val emailResult = validateWithEmailValidator(email)(using emailValidator)
+
+      stringResult.must(beLike { case ValidationResult.Valid(value) =>
+        value must beEqualTo("string: user@example.com")
+      })
+
+      emailResult.must(beLike { case ValidationResult.Valid(value) =>
+        value must beEqualTo("email: user@example.com")
+      })
+    }
+
+    "demonstrate solution for ambiguous givens issue" in {
+      type UserName = String
+
+      /** Namespace containing validators to avoid ambiguity issues with Scala 3.7's givens
+        * prioritization.
+        */
+      object validators {
+        given generalValidator: Validator[String] with {
+          def validate(value: String): ValidationResult[String] =
+            ValidationResult.Valid("from general validator: " + value)
+        }
+
+        given userNameValidator: Validator[UserName] with {
+          def validate(value: UserName): ValidationResult[UserName] =
+            ValidationResult.Valid("from specific validator: " + value)
+        }
+      }
+
+      {
+        import validators.userNameValidator
+
+        val userName: UserName = "test"
+        val result = summon[Validator[UserName]].validate(userName)
+
+        result.must(beLike { case ValidationResult.Valid(value) =>
+          value must beEqualTo("from specific validator: test")
+        })
+      }
+
+      {
+        val userName: UserName = "test"
+        val result = validators.userNameValidator.validate(userName)
+
+        result.must(beLike { case ValidationResult.Valid(value) =>
+          value must beEqualTo("from specific validator: test")
+        })
+      }
+
+      {
+        import validators.generalValidator
+
+        val userName: UserName = "test"
+        val result = summon[Validator[String]].validate(userName)
+
+        result.must(beLike { case ValidationResult.Valid(value) =>
+          value must beEqualTo("from general validator: test")
+        })
+      }
+    }
+
+    "handle inheritance hierarchies correctly" in {
+
+      /** Base trait for animal hierarchy. */
+      trait Animal
+
+      /** Dog implementation with name validation. */
+      case class Dog(name: String) extends Animal
+
+      /** Cat implementation with lives validation. */
+      case class Cat(lives: Int) extends Animal
+
+      given animalValidator: Validator[Animal] with {
+        def validate(value: Animal): ValidationResult[Animal] =
+          ValidationResult.Valid(value)
+      }
+
+      given dogValidator: Validator[Dog] with {
+        def validate(value: Dog): ValidationResult[Dog] =
+          if (value.name.nonEmpty) ValidationResult.Valid(value)
+          else ValidationResult.invalid(ValidationErrors.ValidationError("Dog name cannot be empty"))
+      }
+
+      given catValidator: Validator[Cat] with {
+        def validate(value: Cat): ValidationResult[Cat] =
+          if (value.lives > 0) ValidationResult.Valid(value)
+          else ValidationResult.invalid(ValidationErrors.ValidationError("Cat must have at least one life"))
+      }
+
+      val dog = Dog("Rex")
+      val cat = Cat(9)
+
+      summon[Validator[Dog]].validate(dog) must beEqualTo(ValidationResult.Valid(dog))
+      summon[Validator[Cat]].validate(cat) must beEqualTo(ValidationResult.Valid(cat))
+
+      val dogAsAnimal: Animal = dog
+      val catAsAnimal: Animal = cat
+      summon[Validator[Animal]].validate(dogAsAnimal) must beEqualTo(ValidationResult.Valid(dogAsAnimal))
+      summon[Validator[Animal]].validate(catAsAnimal) must beEqualTo(ValidationResult.Valid(catAsAnimal))
+
+      val emptyNameDog = Dog("")
+      val noLivesCat = Cat(0)
+
+      summon[Validator[Dog]].validate(emptyNameDog) must beLike { case ValidationResult.Invalid(errors) =>
+        errors.head.message must contain("Dog name cannot be empty")
+      }
+
+      summon[Validator[Cat]].validate(noLivesCat) must beLike { case ValidationResult.Invalid(errors) =>
+        errors.head.message must contain("Cat must have at least one life")
+      }
+    }
+  }
+}

--- a/src/test/scala/net/ghoula/valar/TupleValidatorSpec.scala
+++ b/src/test/scala/net/ghoula/valar/TupleValidatorSpec.scala
@@ -1,0 +1,70 @@
+package net.ghoula.valar
+
+import org.specs2.matcher.{Matchers, ResultMatchers, TraversableMatchers}
+import org.specs2.mutable.Specification
+
+import scala.language.implicitConversions
+
+/** Minimal test to check if named tuples work with the existing validator system. */
+object TupleValidatorSpec extends Specification with Matchers with TraversableMatchers with ResultMatchers {
+
+  // Local validators to avoid conflicts with other test files
+  private given localStringValidator: Validator[String] with {
+    def validate(value: String): ValidationResult[String] =
+      if (value.nonEmpty) ValidationResult.Valid(value)
+      else ValidationResult.invalid(ValidationErrors.ValidationError("String must not be empty"))
+  }
+
+  private given localIntValidator: Validator[Int] with {
+    def validate(value: Int): ValidationResult[Int] =
+      if (value >= 0) ValidationResult.Valid(value)
+      else ValidationResult.invalid(ValidationErrors.ValidationError("Int must be non-negative"))
+  }
+
+  // Add tuple validator for regular tuples
+  private given tupleValidator[A, B](using va: Validator[A], vb: Validator[B]): Validator[(A, B)] =
+    Validator.deriveValidatorMacro
+
+  private given namedTupleValidator: Validator[(name: String, age: Int)] =
+    Validator.deriveValidatorMacro
+
+  "Named Tuple Support" should {
+
+    "validate regular tuples with default validators" in {
+      val validTuple = ("hello", 42)
+      val validator = summon[Validator[(String, Int)]]
+      validator.validate(validTuple) must beEqualTo(ValidationResult.Valid(validTuple))
+    }
+
+    "validate named tuples with automatic derivation" in {
+      type PersonTuple = (name: String, age: Int)
+
+      val validPerson: PersonTuple = (name = "Alice", age = 30)
+      val validator = summon[Validator[PersonTuple]]
+
+      validator.validate(validPerson) must beEqualTo(ValidationResult.Valid(validPerson))
+
+      val invalidPerson: PersonTuple = (name = "", age = -10)
+      validator.validate(invalidPerson) must beLike { case ValidationResult.Invalid(errors) =>
+        errors must haveSize(2)
+        errors.map(_.message).must(contain(contain("String must not be empty")))
+        errors.map(_.message).must(contain(contain("Int must be non-negative")))
+        errors.flatMap(_.fieldPath) must containTheSameElementsAs(List("name", "age"))
+      }
+    }
+
+    "demonstrate that named tuples and regular tuples are different types" in {
+      type PersonTuple = (name: String, age: Int)
+      val namedTuple: PersonTuple = (name = "Alice", age = 30)
+      val regularTuple: (String, Int) = ("Alice", 30)
+
+      namedTuple.toTuple must beEqualTo(regularTuple)
+
+      val namedValidator = summon[Validator[PersonTuple]]
+      val regularValidator = summon[Validator[(String, Int)]]
+
+      namedValidator.validate(namedTuple) must beEqualTo(ValidationResult.Valid(namedTuple))
+      regularValidator.validate(regularTuple) must beEqualTo(ValidationResult.Valid(regularTuple))
+    }
+  }
+}

--- a/src/test/scala/net/ghoula/valar/ValidationSpec.scala
+++ b/src/test/scala/net/ghoula/valar/ValidationSpec.scala
@@ -1,16 +1,17 @@
 package net.ghoula.valar
 
-import net.ghoula.valar.ValidationErrors.{ValidationError, ValidationException}
-import net.ghoula.valar.ValidationHelpers.*
-import net.ghoula.valar.ValidationResult.*
-import net.ghoula.valar.Validator.deriveValidatorMacro
-import net.ghoula.valar.internal.ErrorAccumulator
 import org.specs2.matcher.{Matchers, ResultMatchers, TraversableMatchers}
 import org.specs2.mutable.Specification
 
 import scala.collection.immutable.ArraySeq
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
+
+import net.ghoula.valar.ValidationErrors.{ValidationError, ValidationException}
+import net.ghoula.valar.ValidationHelpers.*
+import net.ghoula.valar.ValidationResult.*
+import net.ghoula.valar.Validator.deriveValidatorMacro
+import net.ghoula.valar.internal.ErrorAccumulator
 
 object ValidationSpec extends Specification with Matchers with TraversableMatchers with ResultMatchers {
 


### PR DESCRIPTION
This PR adds comprehensive support for Scala 3.7, focusing on two key improvements:


### Named Tuples Support
Added field-aware error messages for Scala 3.7's named tuples
Implemented compile-time field name extraction with zero runtime overhead
Enhanced validator derivation to handle named tuple types
Includes comprehensive test coverage for named tuple validation
Maintains full backward compatibility with regular tuples

### Givens Prioritization Handling
Addressed the breaking changes in Scala 3.7's givens prioritization algorithm
Added safeguards to ensure consistent validator resolution when multiple instances are available
Updated documentation with specific guidance on handling potential conflicts
Included examples showing proper validator resolution strategies

### Implementation Details
Modified deriveValidatorMacro to detect named tuple types and extract field names at compile time
Enhanced error handling to incorporate field names from named tuples
Implemented priority resolution mechanisms to handle Scala 3.7's changes to ambiguity resolution
Added specific test cases validating both features work correctly
Updated README with examples and compatibility notes

### Compatibility
This release maintains backward compatibility while preparing Valar for the upcoming Scala 3.7 LTS release:


All existing code using regular tuples continues to work unchanged
Users can adopt named tuples incrementally for improved error messages
Explicit guidance provided for handling potential givens conflicts
The changes should make Valar fully compatible with Scala 3.7.